### PR TITLE
feat: Display Balance Sheet Data with Pie Charts in Education

### DIFF
--- a/assets/data/fundamental_lessons.json
+++ b/assets/data/fundamental_lessons.json
@@ -79,18 +79,26 @@
       },
       {
         "id": "fundamental_2_interactive_1",
-        "type": "interactiveChartContent", 
+        "type": "balanceSheetPieChartContent",
         "title": "Örnek Şirket Bilanço Dağılımı (Pasta Grafik)",
-        "explanation": "Bir perakende şirketinin basitleştirilmiş bilanço varlık ve kaynak dağılımını pasta grafiklerle inceleyin. Her bir ana kalemin toplam içindeki payını gözlemleyin. (Bu grafik temsili verilerle oluşturulmuştur ve gerçek bir şirketi yansıtmaz).",
-        "symbol": "PERAKENDE A.Ş. - BİLANÇO",
-        "timeframe": "Yıl Sonu 2023",
-        "chartType": "area",
-        "indicators": [], 
+        "explanation": "Bir perakende şirketinin basitleştirilmiş bilanço varlık ve kaynak dağılımını pasta grafiklerle inceleyin. Her bir ana kalemin toplam içindeki payını gözlemleyebilirsiniz. (Bu grafik temsili verilerle oluşturulmuştur ve gerçek bir şirketi yansıtmaz).",
+        "assetData": {
+          "Nakit ve Nakit Benzerleri": 10.0,
+          "Ticari Alacaklar": 20.0,
+          "Stoklar": 25.0,
+          "Maddi Duran Varlıklar": 35.0,
+          "Diğer Dönen Varlıklar": 10.0
+        },
+        "liabilityEquityData": {
+          "Ticari Borçlar": 15.0,
+          "Kısa Vadeli Finansal Borçlar": 20.0,
+          "Uzun Vadeli Finansal Borçlar": 30.0,
+          "Özkaynaklar": 35.0
+        },
         "annotations": [
-          "Varlıklar: Dönen varlıklar (nakit, alacaklar, stoklar) ve duran varlıklar (mağazalar, ekipmanlar) olarak ayrılır.",
-          "Kaynaklar: Kısa vadeli borçlar, uzun vadeli borçlar ve özkaynaklar (şirket sahiplerinin payı) olarak ayrılır.",
-          "Sağlıklı bir bilançoda varlıkların kaynaklarla dengeli olması, özkaynakların güçlü olması ve likiditenin yeterli olması beklenir.",
-          "Not: Bu grafik türü (area), bilanço kalemlerinin oransal dağılımını göstermek için ideal değildir. Pasta veya yığılmış çubuk grafikler daha uygun olurdu."
+          "Varlıklar: Şirketin sahip olduğu değerleri gösterir. Genellikle dönen varlıklar (nakit, alacaklar, stoklar) ve duran varlıklar (binalar, ekipmanlar) olarak ayrılır.",
+          "Kaynaklar: Şirketin varlıklarını nasıl finanse ettiğini gösterir. Kısa ve uzun vadeli borçlar ile şirket sahiplerinin payı olan özkaynaklardan oluşur.",
+          "Sağlıklı bir bilançoda varlıkların kaynaklarla dengeli olması (Varlıklar = Borçlar + Özkaynaklar), özkaynakların güçlü olması ve şirketin yükümlülüklerini karşılayabilir durumda olması beklenir."
         ]
       }
     ],

--- a/lib/screens/education/models/education_models.dart
+++ b/lib/screens/education/models/education_models.dart
@@ -177,6 +177,8 @@ abstract class LessonContent {
         return FundamentalRatioComparisonChartContent.fromJson(json);
       // case 'fundamentalRatioTimeSeriesChart': // YENİ (Eğer oluşturulursa)
       //   return FundamentalRatioTimeSeriesChartContent.fromJson(json);
+      case 'balanceSheetPieChartContent': // NEW
+        return BalanceSheetPieChartContent.fromJson(json);
       default:
         return TextContent(
             id: json['id'] ?? 'unknown_content_id',
@@ -184,6 +186,47 @@ abstract class LessonContent {
             explanation: json['explanation'] ?? 'Unknown Explanation',
             content: 'Content type "$type" not recognized or missing.');
     }
+  }
+}
+
+// NEW CLASS for Balance Sheet Pie Chart
+class BalanceSheetPieChartContent extends LessonContent {
+  final Map<String, double> assetData;
+  final Map<String, double> liabilityEquityData;
+  final List<String> annotations;
+
+  BalanceSheetPieChartContent({
+    required String id,
+    required String title,
+    required String explanation,
+    required this.assetData,
+    required this.liabilityEquityData,
+    this.annotations = const [],
+  }) : super(
+            id: id,
+            type: 'balanceSheetPieChartContent',
+            title: title,
+            explanation: explanation);
+
+  factory BalanceSheetPieChartContent.fromJson(Map<String, dynamic> json) {
+    return BalanceSheetPieChartContent(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      explanation: json['explanation'] as String? ?? '',
+      assetData: (json['assetData'] as Map<String, dynamic>?)?.map(
+            (k, e) => MapEntry(k, (e as num).toDouble()),
+          ) ??
+          const {},
+      liabilityEquityData:
+          (json['liabilityEquityData'] as Map<String, dynamic>?)?.map(
+            (k, e) => MapEntry(k, (e as num).toDouble()),
+          ) ??
+              const {},
+      annotations: (json['annotations'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const [],
+    );
   }
 }
 

--- a/lib/widgets/interactive_pie_chart.dart
+++ b/lib/widgets/interactive_pie_chart.dart
@@ -10,6 +10,7 @@ class InteractivePieChart extends StatefulWidget {
   final double size;
   final bool showPercentage;
   final bool showLabels;
+  final String? chartTitle;
 
   const InteractivePieChart({
     Key? key,
@@ -17,6 +18,7 @@ class InteractivePieChart extends StatefulWidget {
     this.size = 200,
     this.showPercentage = true,
     this.showLabels = true,
+    this.chartTitle,
   }) : super(key: key);
 
   @override
@@ -158,7 +160,7 @@ class _InteractivePieChartState extends State<InteractivePieChart>
           Padding(
             padding: const EdgeInsets.all(16),
             child: Text(
-              'Asset Allocation',
+              widget.chartTitle ?? 'Asset Allocation',
               style: TextStyle(
                 fontSize: 18,
                 fontWeight: FontWeight.bold,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   connectivity_plus:
     dependency: "direct main"
     description:
@@ -293,10 +293,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -644,10 +644,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -684,10 +684,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -700,10 +700,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -1033,10 +1033,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   sprintf:
     dependency: transitive
     description:
@@ -1089,18 +1089,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   stream_transform:
     dependency: transitive
     description:
@@ -1113,10 +1113,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "0bd04f5bb74fcd6ff0606a888a30e917af9bd52820b178eaa464beb11dca84b6"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   syncfusion_flutter_charts:
     dependency: "direct main"
     description:
@@ -1145,18 +1145,18 @@ packages:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.4"
   timing:
     dependency: transitive
     description:
@@ -1289,10 +1289,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   watcher:
     dependency: transitive
     description:
@@ -1358,5 +1358,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.6.0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.27.0"


### PR DESCRIPTION
I've implemented pie charts for visualizing balance sheet distributions in fundamental analysis education lessons.

Key changes:
- I introduced a new `BalanceSheetPieChartContent` model to represent asset and liability/equity data.
- I updated `LessonContent.fromJson` to parse this new content type.
- I enhanced the existing `InteractivePieChart` widget to accept an optional title, allowing its reuse for displaying asset and liability/equity distributions with appropriate titles ("Varlık Dağılımı" and "Kaynak Dağılımı").
- I implemented a new `_buildBalanceSheetPieChartWidget` method in `LessonDetailScreen` to render the `BalanceSheetPieChartContent` using two instances of the `InteractivePieChart`.
- I modified `assets/data/fundamental_lessons.json`:
    - I updated the lesson "Finansal Tablolar: Bilanço'nun Dili" (fundamental_2) to use the new `balanceSheetPieChartContent` for its interactive balance sheet visualization.
    - I replaced the previous area chart configuration with appropriate `assetData` and `liabilityEquityData` for the pie charts.
    - I updated explanations and annotations to be relevant to the pie chart representation.

This resolves the issue where an area chart was inappropriately used for displaying proportional balance sheet data, as noted in the previous content's annotations.